### PR TITLE
Add bottom nav scaffold and placeholder screens

### DIFF
--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/MainApp.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/MainApp.kt
@@ -1,15 +1,23 @@
 package se.umu.calu0217.smartcalendar
 
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import se.umu.calu0217.smartcalendar.data.repository.AuthRepository
-import se.umu.calu0217.smartcalendar.ui.screens.HomeScreen
+import se.umu.calu0217.smartcalendar.ui.components.BottomNavBar
+import se.umu.calu0217.smartcalendar.ui.screens.AgendaScreen
+import se.umu.calu0217.smartcalendar.ui.screens.CalendarScreen
+import se.umu.calu0217.smartcalendar.ui.screens.SettingsScreen
+import se.umu.calu0217.smartcalendar.ui.screens.TodoScreen
 import se.umu.calu0217.smartcalendar.ui.screens.LoginScreen
 
 @Composable
@@ -19,22 +27,36 @@ fun SmartCalendarApp() {
     val token by repository.token.collectAsState(initial = null)
     val navController = rememberNavController()
 
-    NavHost(
-        navController = navController,
-        startDestination = if (token != null) "home" else "login"
-    ) {
-        composable("login") {
-            LoginScreen(repository) {
-                navController.navigate("home") {
-                    popUpTo("login") { inclusive = true }
+    if (token == null) {
+        NavHost(navController = navController, startDestination = "login") {
+            composable("login") {
+                LoginScreen(repository) {
+                    navController.navigate("agenda") {
+                        popUpTo("login") { inclusive = true }
+                    }
                 }
             }
         }
-        composable("home") {
-            HomeScreen(repository) {
-                navController.navigate("login") {
-                    popUpTo("home") { inclusive = true }
+    } else {
+        BottomNavBar(navController) { innerPadding ->
+            NavHost(
+                navController = navController,
+                startDestination = "agenda",
+                modifier = Modifier.padding(innerPadding)
+            ) {
+                composable("agenda") { AgendaScreen() }
+                composable("calendar") { CalendarScreen() }
+                composable("todos") { TodoScreen() }
+                composable("settings") { SettingsScreen() }
+                composable("logout") {
+                    LaunchedEffect(Unit) {
+                        repository.logout()
+                        navController.navigate("login") {
+                            popUpTo("login") { inclusive = true }
+                        }
+                    }
                 }
+                composable("edit") { Text("Create/Edit") }
             }
         }
     }

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/components/BottomNavBar.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/components/BottomNavBar.kt
@@ -1,0 +1,76 @@
+package se.umu.calu0217.smartcalendar.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.weight
+import androidx.compose.material.BottomAppBar
+import androidx.compose.material.FabPosition
+import androidx.compose.material.FloatingActionButton
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.CalendarToday
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.ExitToApp
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.ViewAgenda
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import androidx.compose.foundation.layout.Row
+
+private data class BottomNavItem(val route: String, val icon: androidx.compose.ui.graphics.vector.ImageVector, val label: String)
+
+@Composable
+fun BottomNavBar(
+    navController: NavController,
+    content: @Composable (androidx.compose.foundation.layout.PaddingValues) -> Unit
+) {
+    val items = listOf(
+        BottomNavItem("agenda", Icons.Filled.ViewAgenda, "Agenda"),
+        BottomNavItem("calendar", Icons.Filled.CalendarToday, "Calendar"),
+        BottomNavItem("todos", Icons.Filled.Check, "Todos"),
+        BottomNavItem("settings", Icons.Filled.Settings, "Settings"),
+        BottomNavItem("logout", Icons.Filled.ExitToApp, "Logout")
+    )
+
+    Scaffold(
+        bottomBar = {
+            BottomAppBar(cutoutShape = androidx.compose.foundation.shape.CircleShape) {
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    items.forEach { item ->
+                        IconButton(
+                            onClick = { navController.navigate(item.route) },
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Icon(
+                                    imageVector = item.icon,
+                                    contentDescription = item.label
+                                )
+                                Text(
+                                    text = item.label,
+                                    fontSize = 10.sp
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        floatingActionButton = {
+            FloatingActionButton(onClick = { navController.navigate("edit") }) {
+                Icon(Icons.Filled.Add, contentDescription = "Create/Edit")
+            }
+        },
+        floatingActionButtonPosition = FabPosition.Center,
+        isFloatingActionButtonDocked = true,
+        content = content
+    )
+}
+

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/AgendaScreen.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/AgendaScreen.kt
@@ -1,0 +1,10 @@
+package se.umu.calu0217.smartcalendar.ui.screens
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun AgendaScreen() {
+    Text("Agenda")
+}
+

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/CalendarScreen.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/CalendarScreen.kt
@@ -1,0 +1,10 @@
+package se.umu.calu0217.smartcalendar.ui.screens
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun CalendarScreen() {
+    Text("Calendar")
+}
+

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/SettingsScreen.kt
@@ -1,0 +1,10 @@
+package se.umu.calu0217.smartcalendar.ui.screens
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun SettingsScreen() {
+    Text("Settings")
+}
+

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/TodoScreen.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/TodoScreen.kt
@@ -1,0 +1,10 @@
+package se.umu.calu0217.smartcalendar.ui.screens
+
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+
+@Composable
+fun TodoScreen() {
+    Text("Todos")
+}
+


### PR DESCRIPTION
## Summary
- Add BottomNavBar scaffold with tabs for agenda, calendar, todos, settings and logout and a centered FAB
- Add placeholder composables for agenda, calendar, todos and settings
- Wire new navigation routes in MainApp with logout routing back to login