### PR TITLE
Snap calendar zoom level after gestures

### DIFF
--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/CalendarScreen.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/CalendarScreen.kt
@@ -41,23 +41,21 @@ fun CalendarScreen() {
                 .fillMaxWidth()
                 .height(300.dp)
                 .pointerInput(Unit) {
-                    detectTransformGestures(
-                        onGesture = { _, _, zoom, _ ->
+                    while (true) {
+                        detectTransformGestures { _, _, zoom, _ ->
                             scale = (scale * zoom).coerceIn(0.5f, 2f)
-                        },
-                        onGestureEnd = {
-                            level = when {
-                                scale < 0.8f -> ZoomLevel.MONTH
-                                scale < 1.5f -> ZoomLevel.WEEK
-                                else -> ZoomLevel.DAY
-                            }
-                            scale = when (level) {
-                                ZoomLevel.MONTH -> 0.8f
-                                ZoomLevel.WEEK -> 1f
-                                ZoomLevel.DAY -> 1.5f
-                            }
                         }
-                    )
+                        level = when {
+                            scale < 0.8f -> ZoomLevel.MONTH
+                            scale < 1.5f -> ZoomLevel.WEEK
+                            else -> ZoomLevel.DAY
+                        }
+                        scale = when (level) {
+                            ZoomLevel.MONTH -> 0.8f
+                            ZoomLevel.WEEK -> 1f
+                            ZoomLevel.DAY -> 1.5f
+                        }
+                    }
                 }
                 .padding(4.dp)
         ) {


### PR DESCRIPTION
## Summary
- Loop gesture detection to keep listening for pinch gestures
- Snap calendar scale to month, week, or day zoom levels after each gesture

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acacf59cdc8325941ad1f3439bfc07