### PR TITLE
Add user settings, stats, and account management

### DIFF
--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/MainApp.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/MainApp.kt
@@ -13,6 +13,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import se.umu.calu0217.smartcalendar.data.repository.AuthRepository
+import se.umu.calu0217.smartcalendar.data.repository.UserRepository
 import se.umu.calu0217.smartcalendar.ui.components.BottomNavBar
 import se.umu.calu0217.smartcalendar.ui.screens.AgendaScreen
 import se.umu.calu0217.smartcalendar.ui.screens.CalendarScreen
@@ -23,14 +24,15 @@ import se.umu.calu0217.smartcalendar.ui.screens.LoginScreen
 @Composable
 fun SmartCalendarApp() {
     val context = LocalContext.current
-    val repository = remember { AuthRepository(context) }
-    val token by repository.token.collectAsState(initial = null)
+    val authRepository = remember { AuthRepository(context) }
+    val userRepository = remember { UserRepository(context) }
+    val token by authRepository.token.collectAsState(initial = null)
     val navController = rememberNavController()
 
     if (token == null) {
         NavHost(navController = navController, startDestination = "login") {
             composable("login") {
-                LoginScreen(repository) {
+                LoginScreen(authRepository) {
                     navController.navigate("agenda") {
                         popUpTo("login") { inclusive = true }
                     }
@@ -47,10 +49,16 @@ fun SmartCalendarApp() {
                 composable("agenda") { AgendaScreen() }
                 composable("calendar") { CalendarScreen() }
                 composable("todos") { TodoScreen() }
-                composable("settings") { SettingsScreen() }
+                composable("settings") {
+                    SettingsScreen(authRepository, userRepository) {
+                        navController.navigate("login") {
+                            popUpTo("login") { inclusive = true }
+                        }
+                    }
+                }
                 composable("logout") {
                     LaunchedEffect(Unit) {
-                        repository.logout()
+                        authRepository.logout()
                         navController.navigate("login") {
                             popUpTo("login") { inclusive = true }
                         }

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/api/AuthApi.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/api/AuthApi.kt
@@ -1,10 +1,17 @@
 package se.umu.calu0217.smartcalendar.data.api
 
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.Header
+import retrofit2.http.HTTP
 import retrofit2.http.POST
+import retrofit2.http.PUT
+import se.umu.calu0217.smartcalendar.domain.ChangeEmailRequest
+import se.umu.calu0217.smartcalendar.domain.ChangePasswordRequest
+import se.umu.calu0217.smartcalendar.domain.DeleteAccountRequest
 import se.umu.calu0217.smartcalendar.domain.LoginRequest
 import se.umu.calu0217.smartcalendar.domain.LoginResponseDTO
+import se.umu.calu0217.smartcalendar.domain.ResponseDTO
 
 interface AuthApi {
     @POST("auth/login")
@@ -12,5 +19,23 @@ interface AuthApi {
 
     @POST("auth/logout")
     suspend fun logout(@Header("Authorization") auth: String)
+
+    @PUT("auth/change-email")
+    suspend fun changeEmail(
+        @Header("Authorization") auth: String,
+        @Body request: ChangeEmailRequest
+    ): ResponseDTO
+
+    @PUT("auth/change-password")
+    suspend fun changePassword(
+        @Header("Authorization") auth: String,
+        @Body request: ChangePasswordRequest
+    ): ResponseDTO
+
+    @HTTP(method = "DELETE", path = "auth/delete-account", hasBody = true)
+    suspend fun deleteAccount(
+        @Header("Authorization") auth: String,
+        @Body request: DeleteAccountRequest
+    ): ResponseDTO
 }
 

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/api/UserApi.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/api/UserApi.kt
@@ -1,0 +1,19 @@
+package se.umu.calu0217.smartcalendar.data.api
+
+import retrofit2.http.GET
+import retrofit2.http.Header
+import se.umu.calu0217.smartcalendar.domain.ActivityStatsDTO
+import se.umu.calu0217.smartcalendar.domain.TaskStatsDTO
+import se.umu.calu0217.smartcalendar.domain.UserDTO
+
+interface UserApi {
+    @GET("user/me")
+    suspend fun getMe(@Header("Authorization") auth: String): UserDTO
+
+    @GET("user/me/stats/tasks")
+    suspend fun getTaskStats(@Header("Authorization") auth: String): TaskStatsDTO
+
+    @GET("user/me/stats/activities")
+    suspend fun getActivityStats(@Header("Authorization") auth: String): ActivityStatsDTO
+}
+

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/repository/AuthRepository.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/repository/AuthRepository.kt
@@ -8,6 +8,9 @@ import retrofit2.converter.moshi.MoshiConverterFactory
 import se.umu.calu0217.smartcalendar.data.TokenDataStore
 import se.umu.calu0217.smartcalendar.data.api.AuthApi
 import se.umu.calu0217.smartcalendar.data.db.AppDatabase
+import se.umu.calu0217.smartcalendar.domain.ChangeEmailRequest
+import se.umu.calu0217.smartcalendar.domain.ChangePasswordRequest
+import se.umu.calu0217.smartcalendar.domain.DeleteAccountRequest
 import se.umu.calu0217.smartcalendar.domain.LoginRequest
 
 class AuthRepository(context: Context) {
@@ -30,6 +33,37 @@ class AuthRepository(context: Context) {
         return try {
             val response = api.login(LoginRequest(email, password))
             dataStore.saveToken(response.accessToken)
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    suspend fun changeEmail(newEmail: String, password: String): Boolean {
+        val token = dataStore.getToken() ?: return false
+        return try {
+            api.changeEmail("Bearer $token", ChangeEmailRequest(newEmail, password))
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    suspend fun changePassword(oldPassword: String, newPassword: String): Boolean {
+        val token = dataStore.getToken() ?: return false
+        return try {
+            api.changePassword("Bearer $token", ChangePasswordRequest(oldPassword, newPassword))
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    suspend fun deleteAccount(password: String): Boolean {
+        val token = dataStore.getToken() ?: return false
+        return try {
+            api.deleteAccount("Bearer $token", DeleteAccountRequest(password))
+            logout()
             true
         } catch (e: Exception) {
             false

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/repository/UserRepository.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/repository/UserRepository.kt
@@ -1,0 +1,48 @@
+package se.umu.calu0217.smartcalendar.data.repository
+
+import android.content.Context
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import se.umu.calu0217.smartcalendar.data.TokenDataStore
+import se.umu.calu0217.smartcalendar.data.api.UserApi
+import se.umu.calu0217.smartcalendar.domain.ActivityStatsDTO
+import se.umu.calu0217.smartcalendar.domain.TaskStatsDTO
+import se.umu.calu0217.smartcalendar.domain.UserDTO
+
+class UserRepository(context: Context) {
+    private val dataStore = TokenDataStore(context)
+
+    private val api: UserApi = Retrofit.Builder()
+        .baseUrl("http://10.0.2.2:8080/api/")
+        .addConverterFactory(MoshiConverterFactory.create())
+        .build()
+        .create(UserApi::class.java)
+
+    suspend fun getMe(): UserDTO? {
+        val token = dataStore.getToken() ?: return null
+        return try {
+            api.getMe("Bearer $token")
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    suspend fun getTaskStats(): TaskStatsDTO? {
+        val token = dataStore.getToken() ?: return null
+        return try {
+            api.getTaskStats("Bearer $token")
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    suspend fun getActivityStats(): ActivityStatsDTO? {
+        val token = dataStore.getToken() ?: return null
+        return try {
+            api.getActivityStats("Bearer $token")
+        } catch (e: Exception) {
+            null
+        }
+    }
+}
+

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/SettingsScreen.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/SettingsScreen.kt
@@ -1,10 +1,141 @@
 package se.umu.calu0217.smartcalendar.ui.screens
 
+import android.graphics.BitmapFactory
+import android.util.Base64
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import se.umu.calu0217.smartcalendar.data.repository.AuthRepository
+import se.umu.calu0217.smartcalendar.data.repository.UserRepository
+import se.umu.calu0217.smartcalendar.domain.ActivityStatsDTO
+import se.umu.calu0217.smartcalendar.domain.TaskStatsDTO
+import se.umu.calu0217.smartcalendar.domain.UserDTO
 
 @Composable
-fun SettingsScreen() {
-    Text("Settings")
+fun SettingsScreen(
+    authRepository: AuthRepository,
+    userRepository: UserRepository,
+    onLogout: () -> Unit
+) {
+    val scope = rememberCoroutineScope()
+    val userState = remember { mutableStateOf<UserDTO?>(null) }
+    val taskStatsState = remember { mutableStateOf<TaskStatsDTO?>(null) }
+    val activityStatsState = remember { mutableStateOf<ActivityStatsDTO?>(null) }
+
+    LaunchedEffect(Unit) {
+        userState.value = userRepository.getMe()
+        taskStatsState.value = userRepository.getTaskStats()
+        activityStatsState.value = userRepository.getActivityStats()
+    }
+
+    val newEmail = remember { mutableStateOf("") }
+    val emailPassword = remember { mutableStateOf("") }
+    val oldPassword = remember { mutableStateOf("") }
+    val newPassword = remember { mutableStateOf("") }
+    val deletePassword = remember { mutableStateOf("") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Top
+    ) {
+        userState.value?.let { user ->
+            val image = user.profileIcon?.let {
+                try {
+                    val bytes = Base64.decode(it, Base64.DEFAULT)
+                    BitmapFactory.decodeByteArray(bytes, 0, bytes.size).asImageBitmap()
+                } catch (e: Exception) {
+                    null
+                }
+            }
+            image?.let {
+                Image(bitmap = it, contentDescription = "Profile Icon")
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+            Text("Name: ${user.fullName}")
+            Text("Email: ${user.email}")
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+
+        taskStatsState.value?.let { stats ->
+            Text("Tasks - Total: ${stats.total}, Completed: ${stats.completed}, Pending: ${stats.pending}")
+        }
+        activityStatsState.value?.let { stats ->
+            Text("Activities - Total: ${stats.total}, Upcoming: ${stats.upcoming}, Ongoing: ${stats.ongoing}")
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+
+        OutlinedTextField(
+            value = newEmail.value,
+            onValueChange = { newEmail.value = it },
+            label = { Text("New Email") }
+        )
+        OutlinedTextField(
+            value = emailPassword.value,
+            onValueChange = { emailPassword.value = it },
+            label = { Text("Current Password") }
+        )
+        Button(onClick = {
+            scope.launch {
+                if (authRepository.changeEmail(newEmail.value, emailPassword.value)) {
+                    userState.value = userRepository.getMe()
+                }
+            }
+        }) { Text("Change Email") }
+        Spacer(modifier = Modifier.height(24.dp))
+
+        OutlinedTextField(
+            value = oldPassword.value,
+            onValueChange = { oldPassword.value = it },
+            label = { Text("Old Password") }
+        )
+        OutlinedTextField(
+            value = newPassword.value,
+            onValueChange = { newPassword.value = it },
+            label = { Text("New Password") }
+        )
+        Button(onClick = {
+            scope.launch { authRepository.changePassword(oldPassword.value, newPassword.value) }
+        }) { Text("Change Password") }
+        Spacer(modifier = Modifier.height(24.dp))
+
+        OutlinedTextField(
+            value = deletePassword.value,
+            onValueChange = { deletePassword.value = it },
+            label = { Text("Password to Delete Account") }
+        )
+        Button(onClick = {
+            scope.launch {
+                if (authRepository.deleteAccount(deletePassword.value)) {
+                    onLogout()
+                }
+            }
+        }) { Text("Delete Account") }
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Button(onClick = {
+            scope.launch {
+                authRepository.logout()
+                onLogout()
+            }
+        }) { Text("Logout") }
+    }
 }
 


### PR DESCRIPTION
## Summary
- fetch user details and stats via new API and repository
- extend auth API/repository for email, password, and account deletion
- build settings screen with profile info, forms, stats, delete and logout

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9927302083259e2e36ffe3a38d78