### PR TITLE
Enable navigation to create/edit screen

### DIFF
--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/MainApp.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/MainApp.kt
@@ -1,6 +1,5 @@
 package se.umu.calu0217.smartcalendar
 
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -10,9 +9,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import se.umu.calu0217.smartcalendar.data.repository.AuthRepository
 import se.umu.calu0217.smartcalendar.data.repository.UserRepository
 import se.umu.calu0217.smartcalendar.ui.components.BottomNavBar
@@ -66,7 +67,22 @@ fun SmartCalendarApp() {
                         }
                     }
                 }
-                composable("edit") { Text("Create/Edit") }
+                composable("edit") {
+                    CreateEditScreen(navController)
+                }
+                composable(
+                    route = "edit?itemId={itemId}",
+                    arguments = listOf(
+                        navArgument("itemId") {
+                            type = NavType.IntType
+                            defaultValue = -1
+                        }
+                    )
+                ) { backStackEntry ->
+                    val id = backStackEntry.arguments?.getInt("itemId")
+                    val itemId = id.takeIf { it != -1 }
+                    CreateEditScreen(navController, itemId)
+                }
             }
         }
     }

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/components/BottomNavBar.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/components/BottomNavBar.kt
@@ -64,7 +64,7 @@ fun BottomNavBar(
         },
         floatingActionButton = {
             FloatingActionButton(onClick = { navController.navigate("edit") }) {
-                Icon(Icons.Filled.Add, contentDescription = "Create/Edit")
+                Icon(Icons.Filled.Add, contentDescription = null)
             }
         },
         floatingActionButtonPosition = FabPosition.Center,

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/CreateEditScreen.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/CreateEditScreen.kt
@@ -2,7 +2,6 @@ package se.umu.calu0217.smartcalendar.ui.screens
 
 import android.Manifest
 import android.app.Activity
-import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
@@ -21,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.core.app.ActivityCompat
+import androidx.navigation.NavController
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import kotlinx.coroutines.launch
@@ -33,7 +33,7 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 @Composable
-fun CreateEditScreen() {
+fun CreateEditScreen(navController: NavController, itemId: Int? = null) {
     val context = LocalContext.current
     val activitiesRepo = remember { ActivitiesRepository(context) }
     val tasksRepo = remember { TasksRepository(context) }
@@ -108,6 +108,7 @@ LaunchedEffect(Unit) {
                 )
                 tasksRepo.create(request)
             }
+            navController.popBackStack()
         }
     }
 


### PR DESCRIPTION
## Summary
- Wire edit route to CreateEditScreen and add optional itemId argument
- Allow CreateEditScreen to navigate back after saving
- Show add icon in FAB without placeholder text