### PR TITLE
Add separate start/end time pickers using LocalDateTime

### DIFF
--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/LocalDateTimeAdapter.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/LocalDateTimeAdapter.kt
@@ -1,0 +1,16 @@
+package se.umu.calu0217.smartcalendar.data
+
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+class LocalDateTimeAdapter {
+    private val formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
+
+    @ToJson
+    fun toJson(value: LocalDateTime): String = value.format(formatter)
+
+    @FromJson
+    fun fromJson(value: String): LocalDateTime = LocalDateTime.parse(value, formatter)
+}

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/repository/ActivitiesRepository.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/repository/ActivitiesRepository.kt
@@ -7,16 +7,17 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.workDataOf
 import kotlinx.coroutines.flow.Flow
+import com.squareup.moshi.Moshi
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import se.umu.calu0217.smartcalendar.data.TokenDataStore
 import se.umu.calu0217.smartcalendar.data.ReminderWorker
+import se.umu.calu0217.smartcalendar.data.LocalDateTimeAdapter
 import se.umu.calu0217.smartcalendar.data.api.ActivityApi
 import se.umu.calu0217.smartcalendar.data.db.ActivityEntity
 import se.umu.calu0217.smartcalendar.data.db.AppDatabase
 import se.umu.calu0217.smartcalendar.domain.ActivityDTO
 import se.umu.calu0217.smartcalendar.domain.CreateActivityRequest
-import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeUnit
@@ -31,9 +32,13 @@ class ActivitiesRepository(context: Context) {
 
     private val workManager = WorkManager.getInstance(context)
 
+    private val moshi = Moshi.Builder()
+        .add(LocalDateTimeAdapter())
+        .build()
+
     private val api: ActivityApi = Retrofit.Builder()
         .baseUrl("http://10.0.2.2:8080/api/")
-        .addConverterFactory(MoshiConverterFactory.create())
+        .addConverterFactory(MoshiConverterFactory.create(moshi))
         .build()
         .create(ActivityApi::class.java)
 
@@ -79,24 +84,22 @@ class ActivitiesRepository(context: Context) {
         }
     }
 
+    private val formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
+
     private fun ActivityDTO.toEntity() = ActivityEntity(
         id = id,
         title = title,
         description = description,
-        startDate = startDate,
-        endDate = endDate,
+        startDate = startDate.format(formatter),
+        endDate = endDate.format(formatter),
         category = category
     )
 
     private fun schedule(activity: ActivityDTO) {
-        val formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
-        val trigger = try {
-            LocalDateTime.parse(activity.startDate, formatter)
-                .atZone(ZoneId.systemDefault())
-                .toInstant().toEpochMilli()
-        } catch (e: Exception) {
-            return
-        }
+        val trigger = activity.startDate
+            .atZone(ZoneId.systemDefault())
+            .toInstant()
+            .toEpochMilli()
         val delay = trigger - System.currentTimeMillis()
         if (delay <= 0) {
             workManager.cancelUniqueWork("activity-${activity.id}")

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/domain/Models.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/domain/Models.kt
@@ -1,5 +1,7 @@
 package se.umu.calu0217.smartcalendar.domain
 
+import java.time.LocalDateTime
+
 data class LoginRequest(
     val email: String,
     val password: String
@@ -28,8 +30,8 @@ data class DeleteAccountRequest(
 data class CreateActivityRequest(
     val title: String,
     val description: String?,
-    val startDate: String,
-    val endDate: String,
+    val startDate: LocalDateTime,
+    val endDate: LocalDateTime,
     val categoryId: Int
 )
 
@@ -37,8 +39,8 @@ data class ActivityDTO(
     val id: Int,
     val title: String,
     val description: String?,
-    val startDate: String,
-    val endDate: String,
+    val startDate: LocalDateTime,
+    val endDate: LocalDateTime,
     val category: String?
 )
 
@@ -56,7 +58,7 @@ data class CategoryDTO(
 data class CreateTaskRequest(
     val title: String,
     val description: String?,
-    val dueDate: String,
+    val dueDate: LocalDateTime,
     val categoryId: Int
 )
 
@@ -64,7 +66,7 @@ data class TaskDTO(
     val id: Int,
     val title: String,
     val description: String?,
-    val dueDate: String,
+    val dueDate: LocalDateTime,
     val completed: Boolean,
     val category: String?,
     val updatedAt: String?


### PR DESCRIPTION
## Summary
- add Moshi adapter for `LocalDateTime` and update repositories to use it
- refactor request/DTO models to use `LocalDateTime`
- add date and time pickers with separate start and end fields in the create/edit screen