### PR TITLE
Add detail screens and navigation for agenda and tasks

### DIFF
--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/MainApp.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/MainApp.kt
@@ -23,6 +23,8 @@ import se.umu.calu0217.smartcalendar.ui.screens.CreateEditScreen
 import se.umu.calu0217.smartcalendar.ui.screens.SettingsScreen
 import se.umu.calu0217.smartcalendar.ui.screens.TodoScreen
 import se.umu.calu0217.smartcalendar.ui.screens.LoginScreen
+import se.umu.calu0217.smartcalendar.ui.screens.ActivityDetailScreen
+import se.umu.calu0217.smartcalendar.ui.screens.TaskDetailScreen
 
 @Composable
 fun SmartCalendarApp() {
@@ -49,9 +51,9 @@ fun SmartCalendarApp() {
                 startDestination = "agenda",
                 modifier = Modifier.padding(innerPadding)
             ) {
-                composable("agenda") { AgendaScreen() }
+                composable("agenda") { AgendaScreen(navController) }
                 composable("calendar") { CalendarScreen() }
-                composable("todos") { TodoScreen() }
+                composable("todos") { TodoScreen(navController) }
                 composable("settings") {
                     SettingsScreen(authRepository, userRepository) {
                         navController.navigate("login") {
@@ -82,6 +84,20 @@ fun SmartCalendarApp() {
                     val id = backStackEntry.arguments?.getInt("itemId")
                     val itemId = id.takeIf { it != -1 }
                     CreateEditScreen(navController, itemId)
+                }
+                composable(
+                    route = "activity/{activityId}",
+                    arguments = listOf(navArgument("activityId") { type = NavType.IntType })
+                ) { backStackEntry ->
+                    val id = backStackEntry.arguments?.getInt("activityId") ?: return@composable
+                    ActivityDetailScreen(navController, id)
+                }
+                composable(
+                    route = "task/{taskId}",
+                    arguments = listOf(navArgument("taskId") { type = NavType.IntType })
+                ) { backStackEntry ->
+                    val id = backStackEntry.arguments?.getInt("taskId") ?: return@composable
+                    TaskDetailScreen(navController, id)
                 }
             }
         }

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/ActivityDetailScreen.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/ActivityDetailScreen.kt
@@ -1,0 +1,79 @@
+package se.umu.calu0217.smartcalendar.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import kotlinx.coroutines.launch
+import androidx.compose.runtime.rememberCoroutineScope
+import se.umu.calu0217.smartcalendar.data.repository.ActivitiesRepository
+import se.umu.calu0217.smartcalendar.ui.viewmodels.ActivitiesViewModel
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@Composable
+fun ActivityDetailScreen(navController: NavController, activityId: Int) {
+    val context = LocalContext.current
+    val viewModel: ActivitiesViewModel =
+        viewModel(factory = ActivitiesViewModel.provideFactory(context))
+    val activities by viewModel.activities.collectAsState()
+    val activity = activities.firstOrNull { it.id == activityId }
+    val repo = remember { ActivitiesRepository(context) }
+    val scope = rememberCoroutineScope()
+
+    if (activity == null) {
+        Text("Loading...", modifier = Modifier.padding(16.dp))
+        return
+    }
+
+    val formatter = remember { DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm") }
+    val start = LocalDateTime.parse(activity.startDate).format(formatter)
+    val end = LocalDateTime.parse(activity.endDate).format(formatter)
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(activity.title, style = MaterialTheme.typography.h4, fontWeight = FontWeight.Bold)
+        activity.description?.let { Text(it) }
+        Text("Start: $start")
+        Text("End: $end")
+        Text("Location: Not specified")
+        Text("Category: ${activity.category ?: "None"}")
+        Spacer(modifier = Modifier.height(16.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(onClick = { navController.navigate("edit?itemId=${activity.id}") }) {
+                Text("Edit")
+            }
+            Button(
+                onClick = {
+                    scope.launch {
+                        repo.delete(activity.id)
+                        navController.popBackStack()
+                    }
+                }
+            ) {
+                Text("Delete")
+            }
+        }
+    }
+}
+

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/AgendaScreen.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/AgendaScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -19,6 +18,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
 import se.umu.calu0217.smartcalendar.ui.viewmodels.ActivitiesViewModel
 import se.umu.calu0217.smartcalendar.ui.viewmodels.TasksViewModel
 import java.time.LocalDate
@@ -26,7 +26,7 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @Composable
-fun AgendaScreen() {
+fun AgendaScreen(navController: NavController) {
     val context = LocalContext.current
     val activitiesViewModel: ActivitiesViewModel =
         viewModel(factory = ActivitiesViewModel.provideFactory(context))
@@ -52,7 +52,8 @@ fun AgendaScreen() {
                 title = activity.title,
                 time = "${activity.startDate.toLocalTime()} - ${activity.endDate.toLocalTime()}",
                 description = activity.description,
-                color = activity.category?.toColor() ?: Color.Gray
+                color = activity.category?.toColor() ?: Color.Gray,
+                onClick = { navController.navigate("activity/${activity.id}") }
             )
         }
         items(todayTasks) { task ->
@@ -60,7 +61,8 @@ fun AgendaScreen() {
                 title = task.title,
                 time = task.dueDate.toLocalTime(),
                 description = task.description,
-                color = task.category?.toColor() ?: Color.Gray
+                color = task.category?.toColor() ?: Color.Gray,
+                onClick = { navController.navigate("task/${task.id}") }
             )
         }
         item { Spacer(modifier = Modifier.height(24.dp)) }
@@ -70,7 +72,8 @@ fun AgendaScreen() {
                 title = activity.title,
                 time = "${activity.startDate.toLocalTime()} - ${activity.endDate.toLocalTime()}",
                 description = activity.description,
-                color = activity.category?.toColor() ?: Color.Gray
+                color = activity.category?.toColor() ?: Color.Gray,
+                onClick = { navController.navigate("activity/${activity.id}") }
             )
         }
         items(tomorrowTasks) { task ->
@@ -78,7 +81,8 @@ fun AgendaScreen() {
                 title = task.title,
                 time = task.dueDate.toLocalTime(),
                 description = task.description,
-                color = task.category?.toColor() ?: Color.Gray
+                color = task.category?.toColor() ?: Color.Gray,
+                onClick = { navController.navigate("task/${task.id}") }
             )
         }
     }
@@ -89,20 +93,20 @@ private fun AgendaItemCard(
     title: String,
     time: String,
     description: String?,
-    color: Color
+    color: Color,
+    onClick: () -> Unit
 ) {
-    val expanded = remember { mutableStateOf(false) }
     Card(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 4.dp)
-            .clickable { expanded.value = !expanded.value },
+            .clickable { onClick() },
         border = BorderStroke(2.dp, color)
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(title, style = MaterialTheme.typography.subtitle1, fontWeight = FontWeight.SemiBold)
             Text(time, style = MaterialTheme.typography.body2)
-            if (expanded.value && !description.isNullOrBlank()) {
+            if (!description.isNullOrBlank()) {
                 Spacer(modifier = Modifier.height(8.dp))
                 Text(description, style = MaterialTheme.typography.body2)
             }

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/TaskDetailScreen.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/TaskDetailScreen.kt
@@ -1,0 +1,77 @@
+package se.umu.calu0217.smartcalendar.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import kotlinx.coroutines.launch
+import androidx.compose.runtime.rememberCoroutineScope
+import se.umu.calu0217.smartcalendar.data.repository.TasksRepository
+import se.umu.calu0217.smartcalendar.ui.viewmodels.TasksViewModel
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@Composable
+fun TaskDetailScreen(navController: NavController, taskId: Int) {
+    val context = LocalContext.current
+    val viewModel: TasksViewModel =
+        viewModel(factory = TasksViewModel.provideFactory(context))
+    val tasks by viewModel.tasks.collectAsState()
+    val task = tasks.firstOrNull { it.id == taskId }
+    val repo = remember { TasksRepository(context) }
+    val scope = rememberCoroutineScope()
+
+    if (task == null) {
+        Text("Loading...", modifier = Modifier.padding(16.dp))
+        return
+    }
+
+    val formatter = remember { DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm") }
+    val due = LocalDateTime.parse(task.dueDate).format(formatter)
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(task.title, style = MaterialTheme.typography.h4, fontWeight = FontWeight.Bold)
+        task.description?.let { Text(it) }
+        Text("Due: $due")
+        Text("Location: Not specified")
+        Text("Category: ${task.category ?: "None"}")
+        Spacer(modifier = Modifier.height(16.dp))
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(onClick = { navController.navigate("edit?itemId=${task.id}") }) {
+                Text("Edit")
+            }
+            Button(
+                onClick = {
+                    scope.launch {
+                        repo.delete(task.id)
+                        navController.popBackStack()
+                    }
+                }
+            ) {
+                Text("Delete")
+            }
+        }
+    }
+}
+

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/TodoScreen.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/TodoScreen.kt
@@ -22,10 +22,11 @@ import se.umu.calu0217.smartcalendar.ui.viewmodels.TasksViewModel
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
+import androidx.navigation.NavController
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
-fun TodoScreen() {
+fun TodoScreen(navController: NavController) {
     val context = LocalContext.current
     val viewModel: TasksViewModel =
         viewModel(factory = TasksViewModel.provideFactory(context))
@@ -138,7 +139,11 @@ fun TodoScreen() {
                         .padding(16.dp)
                 ) {
                     items(filteredTasks) { task ->
-                        TaskCard(task = task) { viewModel.toggleComplete(task.id) }
+                        TaskCard(
+                            task = task,
+                            onToggle = { viewModel.toggleComplete(task.id) },
+                            onClick = { navController.navigate("task/${task.id}") }
+                        )
                     }
                 }
                 PullRefreshIndicator(
@@ -158,11 +163,12 @@ private enum class StatusFilter(val label: String) {
 }
 
 @Composable
-private fun TaskCard(task: TaskEntity, onToggle: () -> Unit) {
+private fun TaskCard(task: TaskEntity, onToggle: () -> Unit, onClick: () -> Unit) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 4.dp),
+            .padding(vertical = 4.dp)
+            .clickable { onClick() },
         border = BorderStroke(2.dp, task.category?.toColor() ?: Color.Gray)
     ) {
         Row(


### PR DESCRIPTION
## Summary
- Create ActivityDetailScreen and TaskDetailScreen showing full info and edit/delete actions
- Navigate from Agenda and Todo lists to their detail views
- Register routes for detail screens in main navigation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af3669b3688325bdaeecd9f6b5d37c