### PR TITLE
Add loading and error state flows to SmartCalendar views

### DIFF
--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/repository/TasksRepository.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/repository/TasksRepository.kt
@@ -47,14 +47,16 @@ class TasksRepository(context: Context) {
 
     val tasks: Flow<List<TaskEntity>> = db.taskDao().getAll()
 
-    suspend fun refresh() {
-        val token = dataStore.getToken() ?: return
-        try {
+    suspend fun refresh(): Result<Unit> {
+        val token = dataStore.getToken() ?: return Result.failure(Exception("No token"))
+        return try {
             syncLocalChanges()
             val remote = api.getAll("Bearer $token")
             db.taskDao().clear()
             db.taskDao().insertAll(remote.map { it.toEntity() })
-        } catch (_: Exception) {
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
         }
     }
 

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/viewmodels/TasksViewModel.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/viewmodels/TasksViewModel.kt
@@ -4,8 +4,10 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import se.umu.calu0217.smartcalendar.data.db.TaskEntity
@@ -19,8 +21,14 @@ class TasksViewModel(private val repository: TasksRepository) : ViewModel() {
             initialValue = emptyList()
         )
 
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val _error = MutableStateFlow<Throwable?>(null)
+    val error: StateFlow<Throwable?> = _error.asStateFlow()
+
     init {
-        viewModelScope.launch { repository.refresh() }
+        refresh()
     }
 
     fun toggleComplete(id: Int) {
@@ -28,7 +36,17 @@ class TasksViewModel(private val repository: TasksRepository) : ViewModel() {
     }
 
     fun refresh() {
-        viewModelScope.launch { repository.refresh() }
+        viewModelScope.launch {
+            _isLoading.value = true
+            _error.value = null
+            val result = repository.refresh()
+            _isLoading.value = false
+            result.exceptionOrNull()?.let { _error.value = it }
+        }
+    }
+
+    fun clearError() {
+        _error.value = null
     }
 
     companion object {


### PR DESCRIPTION
## Summary
- Track loading and error state in TasksViewModel and ActivitiesViewModel
- Surface loading and network errors in agenda, todo, and calendar screens with retry
- Propagate repository refresh errors for activities and tasks