### PR TITLE
Enable editing based on item type

### DIFF
--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/MainApp.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/MainApp.kt
@@ -69,21 +69,22 @@ fun SmartCalendarApp() {
                         }
                     }
                 }
-                composable("edit") {
-                    CreateEditScreen(navController)
-                }
                 composable(
-                    route = "edit?itemId={itemId}",
+                    route = "edit?itemId={itemId}&type={type}",
                     arguments = listOf(
                         navArgument("itemId") {
                             type = NavType.IntType
                             defaultValue = -1
+                        },
+                        navArgument("type") {
+                            type = NavType.StringType
+                            defaultValue = "event"
                         }
                     )
                 ) { backStackEntry ->
-                    val id = backStackEntry.arguments?.getInt("itemId")
-                    val itemId = id.takeIf { it != -1 }
-                    CreateEditScreen(navController, itemId)
+                    val id = backStackEntry.arguments?.getInt("itemId")?.takeIf { it != -1 }
+                    val type = backStackEntry.arguments?.getString("type") ?: "event"
+                    CreateEditScreen(navController, id, type)
                 }
                 composable(
                     route = "activity/{activityId}",

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/repository/ActivitiesRepository.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/repository/ActivitiesRepository.kt
@@ -46,6 +46,8 @@ class ActivitiesRepository(context: Context) {
 
     val activities: Flow<List<ActivityEntity>> = db.activityDao().getAll()
 
+    suspend fun getById(id: Int): ActivityEntity? = db.activityDao().getById(id)
+
     suspend fun refresh(): Result<Unit> {
         val token = dataStore.getToken() ?: return Result.failure(Exception("No token"))
         return try {

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/repository/TasksRepository.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/repository/TasksRepository.kt
@@ -47,6 +47,8 @@ class TasksRepository(context: Context) {
 
     val tasks: Flow<List<TaskEntity>> = db.taskDao().getAll()
 
+    suspend fun getById(id: Int): TaskEntity? = db.taskDao().getById(id)
+
     suspend fun refresh(): Result<Unit> {
         val token = dataStore.getToken() ?: return Result.failure(Exception("No token"))
         return try {

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/components/BottomNavBar.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/components/BottomNavBar.kt
@@ -63,7 +63,7 @@ fun BottomNavBar(
             }
         },
         floatingActionButton = {
-            FloatingActionButton(onClick = { navController.navigate("edit") }) {
+            FloatingActionButton(onClick = { navController.navigate("edit?type=event") }) {
                 Icon(Icons.Filled.Add, contentDescription = null)
             }
         },

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/ActivityDetailScreen.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/ActivityDetailScreen.kt
@@ -73,7 +73,7 @@ fun ActivityDetailScreen(navController: NavController, activityId: Int) {
         Text("Category: ${activity.category ?: "None"}")
         Spacer(modifier = Modifier.height(16.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Button(onClick = { navController.navigate("edit?itemId=${activity.id}") }) {
+            Button(onClick = { navController.navigate("edit?itemId=${activity.id}&type=event") }) {
                 Text("Edit")
             }
             Button(

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/TaskDetailScreen.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/TaskDetailScreen.kt
@@ -71,7 +71,7 @@ fun TaskDetailScreen(navController: NavController, taskId: Int) {
         Text("Category: ${task.category ?: "None"}")
         Spacer(modifier = Modifier.height(16.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Button(onClick = { navController.navigate("edit?itemId=${task.id}") }) {
+            Button(onClick = { navController.navigate("edit?itemId=${task.id}&type=task") }) {
                 Text("Edit")
             }
             Button(


### PR DESCRIPTION
## Summary
- Pass both item id and type when navigating to the edit screen
- Prefill CreateEditScreen with existing data and auto-select type from nav args
- Edit existing items or create new ones based on presence of itemId