### PR TITLE
Preserve screen state across rotations

### DIFF
--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/CalendarScreen.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/CalendarScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -34,9 +35,9 @@ fun CalendarScreen() {
     val error by activitiesViewModel.error.collectAsState()
 
     var scale by remember { mutableStateOf(1f) }
-    var level by remember { mutableStateOf(ZoomLevel.MONTH) }
+    var level by rememberSaveable { mutableStateOf(ZoomLevel.MONTH) }
 
-    var selectedDate by remember { mutableStateOf(LocalDate.now()) }
+    var selectedDate by rememberSaveable { mutableStateOf(LocalDate.now()) }
     val selectedActivities = remember(activities, selectedDate) {
         activities.filter { it.startDate.toLocalDate() == selectedDate }
     }

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/CreateEditScreen.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/CreateEditScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -47,18 +48,18 @@ fun CreateEditScreen(navController: NavController, itemId: Int? = null, type: St
     val categories by categoriesViewModel.categories.collectAsState()
 
     val isEvent = type != "task"
-    var title by remember { mutableStateOf("") }
-    var description by remember { mutableStateOf("") }
-    var startDate by remember { mutableStateOf(LocalDateTime.now()) }
-    var endDate by remember { mutableStateOf(LocalDateTime.now()) }
-    var dueDate by remember { mutableStateOf(LocalDateTime.now()) }
-    var selectedCategory by remember { mutableStateOf<CategoryEntity?>(null) }
-    var categoryExpanded by remember { mutableStateOf(false) }
-    var showCategoryDialog by remember { mutableStateOf(false) }
-    var newCategoryName by remember { mutableStateOf("") }
-    var recurrence by remember { mutableStateOf(Recurrence.NONE) }
-    var recurrenceExpanded by remember { mutableStateOf(false) }
-    var coords by remember { mutableStateOf<Pair<Double, Double>?>(null) }
+    var title by rememberSaveable { mutableStateOf("") }
+    var description by rememberSaveable { mutableStateOf("") }
+    var startDate by rememberSaveable { mutableStateOf(LocalDateTime.now()) }
+    var endDate by rememberSaveable { mutableStateOf(LocalDateTime.now()) }
+    var dueDate by rememberSaveable { mutableStateOf(LocalDateTime.now()) }
+    var selectedCategory by rememberSaveable { mutableStateOf<CategoryEntity?>(null) }
+    var categoryExpanded by rememberSaveable { mutableStateOf(false) }
+    var showCategoryDialog by rememberSaveable { mutableStateOf(false) }
+    var newCategoryName by rememberSaveable { mutableStateOf("") }
+    var recurrence by rememberSaveable { mutableStateOf(Recurrence.NONE) }
+    var recurrenceExpanded by rememberSaveable { mutableStateOf(false) }
+    var coords by rememberSaveable { mutableStateOf<Pair<Double, Double>?>(null) }
 
     val fusedLocation: FusedLocationProviderClient = remember {
         LocationServices.getFusedLocationProviderClient(context)


### PR DESCRIPTION
## Summary
- use rememberSaveable for input fields in CreateEditScreen so text, dates, and selections survive Activity recreation
- use rememberSaveable for level and selectedDate in CalendarScreen to persist state

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af5acf85888325a6239ee2677f98fd