### PR TITLE
Add ReminderReceiver to dispatch notifications via WorkManager

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
         </activity>
 
         <receiver
-            android:name=".ui.screens.ReminderReceiver"
+            android:name=".notifications.ReminderReceiver"
             android:exported="false" />
 
     </application>

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/notifications/ReminderReceiver.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/notifications/ReminderReceiver.kt
@@ -1,0 +1,20 @@
+package se.umu.calu0217.smartcalendar.notifications
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import se.umu.calu0217.smartcalendar.data.ReminderWorker
+
+class ReminderReceiver : BroadcastReceiver() {
+    override fun onReceive(ctx: Context, intent: Intent) {
+        val title = intent.getStringExtra("title") ?: return
+        WorkManager.getInstance(ctx).enqueue(
+            OneTimeWorkRequestBuilder<ReminderWorker>()
+                .setInputData(workDataOf("title" to title))
+                .build()
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- implement ReminderReceiver BroadcastReceiver to enqueue ReminderWorker with WorkManager
- register ReminderReceiver in Android manifest

## Testing
- `./gradlew :app:assembleDebug` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68af6203709c8325b89677ed252a060b