### PR TITLE
chore: use stable library versions

### DIFF
--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
-agp = "8.12.1"
-composeBom = "2025.08.00"
-kotlin = "2.0.21"
-coreKtx = "1.16.0"
+agp = "8.5.2"
+composeBom = "2024.05.00"
+kotlin = "1.9.24"
+coreKtx = "1.13.1"
 junit = "4.13.2"
-junitVersion = "1.2.1"
-espressoCore = "3.6.1"
-appcompat = "1.7.1"
-material = "1.12.0"
-activity = "1.10.1"
-constraintlayout = "2.2.1"
-compose = "1.7.0"
-navigationCompose = "2.8.0"
+junitVersion = "1.1.5"
+espressoCore = "3.5.1"
+appcompat = "1.6.1"
+material = "1.11.0"
+activity = "1.9.0"
+constraintlayout = "2.1.4"
+compose = "1.6.7"
+navigationCompose = "2.7.7"
 retrofit = "2.11.0"
 moshi = "1.15.1"
 room = "2.6.1"
@@ -19,8 +19,8 @@ hilt = "2.51.1"
 hiltNavigationCompose = "1.2.0"
 datastore = "1.1.1"
 playServicesLocation = "21.3.0"
-uiToolingPreview = "1.9.0"
-uiTooling = "1.9.0"
+uiToolingPreview = "1.6.7"
+uiTooling = "1.6.7"
 work = "2.9.0"
 
 [libraries]
@@ -36,7 +36,7 @@ androidx-activity = { group = "androidx.activity", name = "activity", version.re
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "compose" }
 androidx-compose-material = { group = "androidx.compose.material", name = "material", version.ref = "compose" }
-androidx-compose-material-pullrefresh = { group = "androidx.compose.material", name = "material-pull-refresh", version.ref = "compose" }
+androidx-compose-material-pullrefresh = { group = "androidx.compose.material", name = "pullrefresh", version.ref = "compose" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-converter-moshi = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "retrofit" }


### PR DESCRIPTION
## Summary
- rely on stable AndroidX, Compose, and Kotlin versions
- correct pull-refresh artifact name