### PR TITLE
Refactor ActivitiesViewModel to use Hilt

### DIFF
--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/ActivityDetailScreen.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/ActivityDetailScreen.kt
@@ -21,11 +21,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import kotlinx.coroutines.launch
 import androidx.compose.runtime.rememberCoroutineScope
-import se.umu.calu0217.smartcalendar.data.repository.ActivitiesRepository
 import se.umu.calu0217.smartcalendar.ui.viewmodels.ActivitiesViewModel
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -33,11 +32,9 @@ import java.time.format.DateTimeFormatter
 @Composable
 fun ActivityDetailScreen(navController: NavController, activityId: Int) {
     val context = LocalContext.current
-    val viewModel: ActivitiesViewModel =
-        viewModel(factory = ActivitiesViewModel.provideFactory(context))
+    val viewModel: ActivitiesViewModel = hiltViewModel()
     val activities by viewModel.activities.collectAsState()
     val activity = activities.firstOrNull { it.id == activityId }
-    val repo = remember { ActivitiesRepository(context) }
     val scope = rememberCoroutineScope()
 
     if (activity == null) {
@@ -79,7 +76,7 @@ fun ActivityDetailScreen(navController: NavController, activityId: Int) {
             Button(
                 onClick = {
                     scope.launch {
-                        repo.delete(activity.id)
+                        viewModel.delete(activity.id)
                         navController.popBackStack()
                     }
                 }

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/CreateEditScreen.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/CreateEditScreen.kt
@@ -32,9 +32,10 @@ import androidx.work.WorkManager
 import androidx.work.workDataOf
 import se.umu.calu0217.smartcalendar.data.ReminderWorker
 import java.util.concurrent.TimeUnit
-import se.umu.calu0217.smartcalendar.data.repository.ActivitiesRepository
 import se.umu.calu0217.smartcalendar.data.repository.TasksRepository
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
+import se.umu.calu0217.smartcalendar.ui.viewmodels.ActivitiesViewModel
 import se.umu.calu0217.smartcalendar.data.db.CategoryEntity
 import se.umu.calu0217.smartcalendar.ui.viewmodels.CategoriesViewModel
 import se.umu.calu0217.smartcalendar.domain.CreateActivityRequest
@@ -48,7 +49,7 @@ import java.util.Locale
 @Composable
 fun CreateEditScreen(navController: NavController, itemId: Int? = null, type: String = "event") {
     val context = LocalContext.current
-    val activitiesRepo = remember { ActivitiesRepository(context) }
+    val activitiesViewModel: ActivitiesViewModel = hiltViewModel()
     val tasksRepo = remember { TasksRepository(context) }
     val categoriesViewModel: CategoriesViewModel = viewModel(factory = CategoriesViewModel.provideFactory(context))
     val categories by categoriesViewModel.categories.collectAsState()
@@ -76,7 +77,7 @@ fun CreateEditScreen(navController: NavController, itemId: Int? = null, type: St
     LaunchedEffect(itemId, categories) {
         if (itemId != null) {
             if (isEvent) {
-                activitiesRepo.getById(itemId)?.let { activity ->
+                activitiesViewModel.getById(itemId)?.let { activity ->
                     title = activity.title
                     description = activity.description ?: ""
                     startDate = LocalDateTime.parse(activity.startDate)
@@ -149,9 +150,9 @@ LaunchedEffect(Unit) {
                     recurrence = recurrence
                 )
                 if (itemId != null) {
-                    activitiesRepo.edit(itemId, request)
+                    activitiesViewModel.edit(itemId, request)
                 } else {
-                    activitiesRepo.create(request)
+                    activitiesViewModel.create(request)
                 }
             } else {
                 val request = CreateTaskRequest(

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/viewmodels/ActivitiesViewModel.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/viewmodels/ActivitiesViewModel.kt
@@ -1,9 +1,9 @@
 package se.umu.calu0217.smartcalendar.ui.viewmodels
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -12,8 +12,12 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import se.umu.calu0217.smartcalendar.data.db.ActivityEntity
 import se.umu.calu0217.smartcalendar.data.repository.ActivitiesRepository
+import se.umu.calu0217.smartcalendar.domain.CreateActivityRequest
 
-class ActivitiesViewModel(private val repository: ActivitiesRepository) : ViewModel() {
+@HiltViewModel
+class ActivitiesViewModel @Inject constructor(
+    private val repository: ActivitiesRepository
+) : ViewModel() {
     val activities: StateFlow<List<ActivityEntity>> =
         repository.activities.stateIn(
             scope = viewModelScope,
@@ -45,16 +49,13 @@ class ActivitiesViewModel(private val repository: ActivitiesRepository) : ViewMo
         _error.value = null
     }
 
-    companion object {
-        fun provideFactory(context: Context): ViewModelProvider.Factory =
-            object : ViewModelProvider.Factory {
-                override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                    val repo = ActivitiesRepository(context)
-                    @Suppress("UNCHECKED_CAST")
-                    return ActivitiesViewModel(repo) as T
-                }
-            }
-    }
+    suspend fun getById(id: Int): ActivityEntity? = repository.getById(id)
+
+    suspend fun create(request: CreateActivityRequest) = repository.create(request)
+
+    suspend fun edit(id: Int, request: CreateActivityRequest) = repository.edit(id, request)
+
+    suspend fun delete(id: Int) = repository.delete(id)
 }
 
 


### PR DESCRIPTION
## Summary
- convert ActivitiesViewModel to a Hilt view model with injected ActivitiesRepository
- use hiltViewModel in CreateEditScreen and ActivityDetailScreen
- call repository operations through the view model instead of direct instantiation

## Testing
- `./gradlew app:test` *(fails: project 'app' not found in root project 'SmartCalendar')*

------
https://chatgpt.com/codex/tasks/task_e_68b060f9a63083258ab104e49100925d