### PR TITLE
Disable Room schema export

### DIFF
--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/db/AppDatabase.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/db/AppDatabase.kt
@@ -5,7 +5,8 @@ import androidx.room.RoomDatabase
 
 @Database(
     entities = [ActivityEntity::class, TaskEntity::class, CategoryEntity::class],
-    version = 5
+    version = 5,
+    exportSchema = false,
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun activityDao(): ActivityDao


### PR DESCRIPTION
## Summary
- add `exportSchema = false` to Room database to avoid schema export requirement