### PR TITLE
Add auth interceptor and simplify repositories

### DIFF
--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/api/ActivityApi.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/api/ActivityApi.kt
@@ -3,7 +3,6 @@ package se.umu.calu0217.smartcalendar.data.api
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
-import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Path
@@ -14,48 +13,38 @@ import se.umu.calu0217.smartcalendar.domain.CreateActivityRequest
 interface ActivityApi {
     @GET("activities/{id}")
     suspend fun getById(
-        @Header("Authorization") auth: String,
         @Path("id") id: Int
     ): ActivityDTO
 
     @POST("activities/create")
     suspend fun create(
-        @Header("Authorization") auth: String,
         @Body request: CreateActivityRequest
     ): ActivityDTO
 
     @PUT("activities/edit/{id}")
     suspend fun edit(
-        @Header("Authorization") auth: String,
         @Path("id") id: Int,
         @Body request: CreateActivityRequest
     )
 
     @DELETE("activities/delete/{id}")
     suspend fun delete(
-        @Header("Authorization") auth: String,
         @Path("id") id: Int
     )
 
     @GET("activities/ongoing")
-    suspend fun getOngoing(
-        @Header("Authorization") auth: String
-    ): List<ActivityDTO>
+    suspend fun getOngoing(): List<ActivityDTO>
 
     @GET("activities/future")
-    suspend fun getFuture(
-        @Header("Authorization") auth: String
-    ): List<ActivityDTO>
+    suspend fun getFuture(): List<ActivityDTO>
 
     @GET("activities/category/{categoryId}")
     suspend fun getByCategory(
-        @Header("Authorization") auth: String,
         @Path("categoryId") categoryId: Int
     ): List<ActivityDTO>
 
     @GET("activities/between")
     suspend fun getBetween(
-        @Header("Authorization") auth: String,
         @Query("start") start: String,
         @Query("end") end: String
     ): List<ActivityDTO>

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/api/AuthApi.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/api/AuthApi.kt
@@ -2,7 +2,6 @@ package se.umu.calu0217.smartcalendar.data.api
 
 import retrofit2.http.Body
 import retrofit2.http.DELETE
-import retrofit2.http.Header
 import retrofit2.http.HTTP
 import retrofit2.http.POST
 import retrofit2.http.PUT
@@ -18,23 +17,20 @@ interface AuthApi {
     suspend fun login(@Body request: LoginRequest): LoginResponseDTO
 
     @POST("auth/logout")
-    suspend fun logout(@Header("Authorization") auth: String)
+    suspend fun logout()
 
     @PUT("auth/change-email")
     suspend fun changeEmail(
-        @Header("Authorization") auth: String,
         @Body request: ChangeEmailRequest
     ): ResponseDTO
 
     @PUT("auth/change-password")
     suspend fun changePassword(
-        @Header("Authorization") auth: String,
         @Body request: ChangePasswordRequest
     ): ResponseDTO
 
     @HTTP(method = "DELETE", path = "auth/delete-account", hasBody = true)
     suspend fun deleteAccount(
-        @Header("Authorization") auth: String,
         @Body request: DeleteAccountRequest
     ): ResponseDTO
 }

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/api/CategoryApi.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/api/CategoryApi.kt
@@ -3,7 +3,6 @@ package se.umu.calu0217.smartcalendar.data.api
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
-import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Path
@@ -12,32 +11,26 @@ import se.umu.calu0217.smartcalendar.domain.CreateCategoryRequest
 
 interface CategoryApi {
     @GET("categories/all")
-    suspend fun getAll(
-        @Header("Authorization") auth: String
-    ): List<CategoryDTO>
+    suspend fun getAll(): List<CategoryDTO>
 
     @GET("categories/{id}")
     suspend fun getById(
-        @Header("Authorization") auth: String,
         @Path("id") id: Int
     ): CategoryDTO
 
     @POST("categories/create")
     suspend fun create(
-        @Header("Authorization") auth: String,
         @Body request: CreateCategoryRequest
     ): CategoryDTO
 
     @PUT("categories/edit/{id}")
     suspend fun edit(
-        @Header("Authorization") auth: String,
         @Path("id") id: Int,
         @Body request: CreateCategoryRequest
     ): CategoryDTO
 
     @DELETE("categories/delete/{id}")
     suspend fun delete(
-        @Header("Authorization") auth: String,
         @Path("id") id: Int
     )
 }

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/api/TaskApi.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/api/TaskApi.kt
@@ -3,7 +3,6 @@ package se.umu.calu0217.smartcalendar.data.api
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
-import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Path
@@ -13,50 +12,41 @@ import se.umu.calu0217.smartcalendar.domain.TaskDTO
 
 interface TaskApi {
     @GET("tasks/all")
-    suspend fun getAll(
-        @Header("Authorization") auth: String
-    ): List<TaskDTO>
+    suspend fun getAll(): List<TaskDTO>
 
     @GET("tasks/{id}")
     suspend fun getById(
-        @Header("Authorization") auth: String,
         @Path("id") id: Int
     ): TaskDTO
 
     @POST("tasks/create")
     suspend fun create(
-        @Header("Authorization") auth: String,
         @Body request: CreateTaskRequest
     ): TaskDTO
 
     @PUT("tasks/edit/{id}")
     suspend fun edit(
-        @Header("Authorization") auth: String,
         @Path("id") id: Int,
         @Body request: CreateTaskRequest
     ): TaskDTO
 
     @DELETE("tasks/delete/{id}")
     suspend fun delete(
-        @Header("Authorization") auth: String,
         @Path("id") id: Int
     )
 
     @PUT("tasks/{id}/complete")
     suspend fun toggleComplete(
-        @Header("Authorization") auth: String,
         @Path("id") id: Int
     )
 
     @GET("tasks/category/{categoryId}")
     suspend fun getByCategory(
-        @Header("Authorization") auth: String,
         @Path("categoryId") categoryId: Int
     ): List<TaskDTO>
 
     @POST("tasks/convert/{id}")
     suspend fun convert(
-        @Header("Authorization") auth: String,
         @Path("id") id: Int,
         @Body request: ConvertTaskRequest
     )

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/api/UserApi.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/api/UserApi.kt
@@ -1,19 +1,18 @@
 package se.umu.calu0217.smartcalendar.data.api
 
 import retrofit2.http.GET
-import retrofit2.http.Header
 import se.umu.calu0217.smartcalendar.domain.ActivityStatsDTO
 import se.umu.calu0217.smartcalendar.domain.TaskStatsDTO
 import se.umu.calu0217.smartcalendar.domain.UserDTO
 
 interface UserApi {
     @GET("user/me")
-    suspend fun getMe(@Header("Authorization") auth: String): UserDTO
+    suspend fun getMe(): UserDTO
 
     @GET("user/me/stats/tasks")
-    suspend fun getTaskStats(@Header("Authorization") auth: String): TaskStatsDTO
+    suspend fun getTaskStats(): TaskStatsDTO
 
     @GET("user/me/stats/activities")
-    suspend fun getActivityStats(@Header("Authorization") auth: String): ActivityStatsDTO
+    suspend fun getActivityStats(): ActivityStatsDTO
 }
 

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/di/NetworkModule.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/di/NetworkModule.kt
@@ -1,15 +1,19 @@
 package se.umu.calu0217.smartcalendar.data.di
 
+import android.content.Context
 import com.squareup.moshi.Moshi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 import se.umu.calu0217.smartcalendar.BuildConfig
 import se.umu.calu0217.smartcalendar.data.LocalDateTimeAdapter
+import se.umu.calu0217.smartcalendar.data.TokenDataStore
+import se.umu.calu0217.smartcalendar.data.network.AuthInterceptor
 import javax.inject.Singleton
 
 @Module
@@ -18,7 +22,12 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideOkHttpClient(): OkHttpClient = OkHttpClient.Builder().build()
+    fun provideOkHttpClient(@ApplicationContext context: Context): OkHttpClient {
+        val dataStore = TokenDataStore(context)
+        return OkHttpClient.Builder()
+            .addInterceptor(AuthInterceptor(dataStore))
+            .build()
+    }
 
     @Provides
     @Singleton

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/network/AuthInterceptor.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/network/AuthInterceptor.kt
@@ -1,0 +1,20 @@
+package se.umu.calu0217.smartcalendar.data.network
+
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+import se.umu.calu0217.smartcalendar.data.TokenDataStore
+
+class AuthInterceptor(private val dataStore: TokenDataStore) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val token = runBlocking { dataStore.getToken() }
+        val request = if (token != null) {
+            chain.request().newBuilder()
+                .addHeader("Authorization", "Bearer $token")
+                .build()
+        } else {
+            chain.request()
+        }
+        return chain.proceed(request)
+    }
+}

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/repository/UserRepository.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/data/repository/UserRepository.kt
@@ -1,48 +1,36 @@
 package se.umu.calu0217.smartcalendar.data.repository
 
-import android.content.Context
 import retrofit2.Retrofit
-import retrofit2.converter.moshi.MoshiConverterFactory
-import se.umu.calu0217.smartcalendar.BuildConfig
-import se.umu.calu0217.smartcalendar.data.TokenDataStore
 import se.umu.calu0217.smartcalendar.data.api.UserApi
 import se.umu.calu0217.smartcalendar.domain.ActivityStatsDTO
 import se.umu.calu0217.smartcalendar.domain.TaskStatsDTO
 import se.umu.calu0217.smartcalendar.domain.UserDTO
-import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
-class UserRepository @Inject constructor(@ApplicationContext context: Context) {
-    private val dataStore = TokenDataStore(context)
-
-    private val api: UserApi = Retrofit.Builder()
-        .baseUrl(BuildConfig.BASE_URL)
-        .addConverterFactory(MoshiConverterFactory.create())
-        .build()
-        .create(UserApi::class.java)
+class UserRepository @Inject constructor(
+    retrofit: Retrofit
+) {
+    private val api: UserApi = retrofit.create(UserApi::class.java)
 
     suspend fun getMe(): UserDTO? {
-        val token = dataStore.getToken() ?: return null
         return try {
-            api.getMe("Bearer $token")
+            api.getMe()
         } catch (e: Exception) {
             null
         }
     }
 
     suspend fun getTaskStats(): TaskStatsDTO? {
-        val token = dataStore.getToken() ?: return null
         return try {
-            api.getTaskStats("Bearer $token")
+            api.getTaskStats()
         } catch (e: Exception) {
             null
         }
     }
 
     suspend fun getActivityStats(): ActivityStatsDTO? {
-        val token = dataStore.getToken() ?: return null
         return try {
-            api.getActivityStats("Bearer $token")
+            api.getActivityStats()
         } catch (e: Exception) {
             null
         }


### PR DESCRIPTION
## Summary
- add `AuthInterceptor` that pulls tokens from `TokenDataStore`
- register interceptor in `NetworkModule`
- simplify repositories to rely on OkHttp for auth headers

## Testing
- `./gradlew test` *(fails: Task 'test' not found in root project 'SmartCalendar')*
- `./gradlew projects` *(fails: Skipping :app — no valid Android SDK detected)*

------
https://chatgpt.com/codex/tasks/task_e_68b0901c48a483258748d7a5115cc219