### PR TITLE
Use hiltViewModel for ActivitiesViewModel on screens

### DIFF
--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/AgendaScreen.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/AgendaScreen.kt
@@ -9,9 +9,10 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import se.umu.calu0217.smartcalendar.ui.viewmodels.ActivitiesViewModel
@@ -23,8 +24,7 @@ import java.time.format.DateTimeFormatter
 @Composable
 fun AgendaScreen(navController: NavController) {
     val context = LocalContext.current
-    val activitiesViewModel: ActivitiesViewModel =
-        viewModel(factory = ActivitiesViewModel.provideFactory(context))
+    val activitiesViewModel: ActivitiesViewModel = hiltViewModel()
     val tasksViewModel: TasksViewModel =
         viewModel(factory = TasksViewModel.provideFactory(context))
 

--- a/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/CalendarScreen.kt
+++ b/android/app/src/main/java/se/umu/calu0217/smartcalendar/ui/screens/CalendarScreen.kt
@@ -16,10 +16,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import se.umu.calu0217.smartcalendar.data.db.ActivityEntity
 import se.umu.calu0217.smartcalendar.ui.viewmodels.ActivitiesViewModel
 import java.time.DayOfWeek
@@ -28,9 +27,7 @@ import java.time.LocalDateTime
 
 @Composable
 fun CalendarScreen() {
-    val context = LocalContext.current
-    val activitiesViewModel: ActivitiesViewModel =
-        viewModel(factory = ActivitiesViewModel.provideFactory(context))
+    val activitiesViewModel: ActivitiesViewModel = hiltViewModel()
     val activities by activitiesViewModel.activities.collectAsState()
     val isLoading by activitiesViewModel.isLoading.collectAsState()
     val error by activitiesViewModel.error.collectAsState()


### PR DESCRIPTION
## Summary
- Replace manual ActivitiesViewModel factory with `hiltViewModel` in Agenda and Calendar screens

## Testing
- `FORCE_ANDROID=true ./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bc905960832588e3718334aabf86